### PR TITLE
Fix schedule fail when column uniq

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    delay_henka (0.3.1)
+    delay_henka (0.3.2)
       haml (= 5.0.4)
       keka
       rails (~> 5.2)

--- a/app/services/delay_henka/whether_schedule.rb
+++ b/app/services/delay_henka/whether_schedule.rb
@@ -6,10 +6,9 @@ module DelayHenka
     end
 
     def make_decision(attribute, new_val)
-      result = evaluate_decision(attribute, new_val)
-      # restore attributes
-      @record.restore_attributes
-      result
+      evaluate_decision(attribute, new_val).tap do
+        @record.restore_attributes
+      end
     end
 
     def evaluate_decision(attribute, new_val)

--- a/app/services/delay_henka/whether_schedule.rb
+++ b/app/services/delay_henka/whether_schedule.rb
@@ -2,14 +2,20 @@ module DelayHenka
   class WhetherSchedule
 
     def initialize(record)
-      @record = record.dup
+      @record = record
     end
 
     def make_decision(attribute, new_val)
+      result = evaluate_decision(attribute, new_val)
+      # restore attributes
+      @record.restore_attributes
+      result
+    end
+
+    def evaluate_decision(attribute, new_val)
       Keka.run do
         old_val = record.public_send(attribute)
         record.public_send("#{attribute}=", new_val)
-        # can't use xxx_changed? because #dup gives us a new instance
         Keka.err_if! old_val == record.public_send(attribute)
         Keka.ok_if! record.valid?
         Keka.err_if! true, record.errors.full_messages.join(', ')

--- a/lib/delay_henka/version.rb
+++ b/lib/delay_henka/version.rb
@@ -1,3 +1,3 @@
 module DelayHenka
-  VERSION = '0.3.1'
+  VERSION = '0.3.2'
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -67,7 +67,7 @@ RSpec.configure do |config|
 
     module DelayHenka
       class Foo < ApplicationRecord
-        validates :attr_chars, presence: true
+        validates :attr_chars, presence: true, uniqueness: true
         validates :attr_int, numericality: { greater_than: 1 }, allow_nil: true
         after_initialize -> { self.attr_chars ||= 'init' }, if: :new_record?
       end

--- a/spec/services/delay_henka/whether_schedule_spec.rb
+++ b/spec/services/delay_henka/whether_schedule_spec.rb
@@ -13,6 +13,12 @@ module DelayHenka
         expect{ service.make_decision(:attr_int, nil) }.not_to change{ record.attr_int }.from(10)
       end
 
+      it 'does not returns err when have uniq column' do
+        output = service.make_decision(:attr_int, 7)
+        expect(output).to be_ok
+        expect(output.msg).to be_nil
+      end
+
       it 'returns err keka without msg when there is no change' do
         output = service.make_decision(:attr_int, 10)
         expect(output).not_to be_ok


### PR DESCRIPTION
when make decision, it use `record.dup`, when the model have uniqueness column, then it leads to validate fail wrongly.