### PR TITLE
introduce time_zone parameters to schedule methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 ## Unreleased
 
+## Version 0.6.1
+* Introduce time_zone as parameter on schedule method for ScheduledChange and ScheduledAction.
+
 ## Version 0.6.0
-* Add service_region_id and timezone migrations.
+* Add service_region_id and time_zone migrations.
 
 ## Version 0.5.3
 Unrecorded.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    delay_henka (0.6.0)
+    delay_henka (0.6.1)
       haml (> 5)
       keka
       rails (> 5.2)

--- a/app/models/delay_henka/scheduled_action.rb
+++ b/app/models/delay_henka/scheduled_action.rb
@@ -15,7 +15,7 @@ module DelayHenka
 
     scope :staged, -> { where(state: STATES[:STAGED]) }
 
-    def self.schedule(record:, method_name:, argument: nil, by_id:, schedule_at: Time.current)
+    def self.schedule(record:, method_name:, argument: nil, by_id:, schedule_at: Time.current, time_zone: nil)
       Keka.run do
         begin
           arity = record.method(method_name.to_sym).arity
@@ -25,7 +25,8 @@ module DelayHenka
             method_name: method_name,
             argument: argument.to_json,
             submitted_by_id: by_id,
-            schedule_at: schedule_at
+            schedule_at: schedule_at,
+            time_zone: time_zone
           )
         rescue NameError => e
           Keka.err_if! true, e.message

--- a/app/models/delay_henka/scheduled_change.rb
+++ b/app/models/delay_henka/scheduled_change.rb
@@ -17,7 +17,7 @@ module DelayHenka
 
     scope :staged, -> { where(state: STATES[:STAGED]) }
 
-    def self.schedule(record:, changes:, by_id:, schedule_at: Time.current)
+    def self.schedule(record:, changes:, by_id:, schedule_at: Time.current, time_zone: nil)
       Keka.run do
         service = WhetherSchedule.new(record)
         new_changes = changes.each_with_object([]) do |(attribute, new_val), accum|
@@ -31,7 +31,8 @@ module DelayHenka
               attribute_name: attribute,
               old_value: old_val,
               new_value: cleaned_new_val,
-              schedule_at: schedule_at
+              schedule_at: schedule_at,
+              time_zone: time_zone
             )
           elsif decision.msg
             return decision # error present

--- a/app/views/delay_henka/web/admin/scheduled_actions/_summary_table.html.haml
+++ b/app/views/delay_henka/web/admin/scheduled_actions/_summary_table.html.haml
@@ -10,6 +10,7 @@
       %th Action
       %th Arguments
       %th Schedule At
+      %th Time Zone
       %th Action
   %tbody
     - scheduled_actions.each do |action|
@@ -17,4 +18,5 @@
         %td= action.method_name
         %td= action.argument
         %td= action.schedule_at
+        %td= action.time_zone
         %td= link_to 'Delete', delay_henka.web_admin_scheduled_action_path(action), method: :delete

--- a/app/views/delay_henka/web/admin/scheduled_actions/index.html.haml
+++ b/app/views/delay_henka/web/admin/scheduled_actions/index.html.haml
@@ -9,6 +9,7 @@
       %th State
       %th Return Value
       %th Schedule At
+      %th Time Zone
       %th Submitted By
   %tbody
     - @actions.each do |action|
@@ -20,4 +21,5 @@
         %td= action.state
         %td= action.return_value
         %td= action.schedule_at
+        %td= action.time_zone
         %td= action.submitted_by_id

--- a/app/views/delay_henka/web/admin/scheduled_changes/_summary_table.html.haml
+++ b/app/views/delay_henka/web/admin/scheduled_changes/_summary_table.html.haml
@@ -11,6 +11,7 @@
       %th Old Value
       %th New Value
       %th Schedule At
+      %th Time Zone
       %th Action
   %tbody
     - scheduled_changes.each do |change|
@@ -19,4 +20,5 @@
         %td= change.old_value
         %td= change.new_value
         %td= change.schedule_at
+        %td= change.time_zone
         %td= link_to 'Delete', delay_henka.web_admin_scheduled_change_path(change), method: :delete

--- a/app/views/delay_henka/web/admin/scheduled_changes/index.html.haml
+++ b/app/views/delay_henka/web/admin/scheduled_changes/index.html.haml
@@ -9,6 +9,7 @@
       %th Old Value
       %th New Value
       %th Schedule At
+      %th Time Zone
       %th Submitted By
   %tbody
     - @changes.each do |change|
@@ -20,4 +21,5 @@
         %td= change.old_value
         %td= change.new_value
         %td= change.schedule_at
+        %td= change.time_zone
         %td= change.submitted_by_id

--- a/lib/delay_henka/version.rb
+++ b/lib/delay_henka/version.rb
@@ -1,3 +1,3 @@
 module DelayHenka
-  VERSION = '0.6.0'
+  VERSION = '0.6.1'
 end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_08_130947) do
+ActiveRecord::Schema.define(version: 2020_07_24_150636) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,9 +27,12 @@ ActiveRecord::Schema.define(version: 2019_04_08_130947) do
     t.jsonb "return_value"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "time_zone"
+    t.integer "service_region_id"
     t.index ["actionable_type", "actionable_id"], name: "actionable_index"
     t.index ["schedule_at"], name: "index_delay_henka_scheduled_actions_on_schedule_at"
     t.index ["state"], name: "index_delay_henka_scheduled_actions_on_state"
+    t.index ["time_zone"], name: "index_delay_henka_scheduled_actions_on_time_zone"
   end
 
   create_table "delay_henka_scheduled_changes", force: :cascade do |t|
@@ -44,6 +47,9 @@ ActiveRecord::Schema.define(version: 2019_04_08_130947) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "schedule_at", null: false
+    t.string "time_zone"
+    t.integer "service_region_id"
+    t.index ["time_zone"], name: "index_delay_henka_scheduled_changes_on_time_zone"
   end
 
 end


### PR DESCRIPTION
Adding `time_zone` as a parameter to `ScheduledChanges.schedule` and `ScheduledActions.schedule`.  For now, we will be assigning it a default value of `nil`.

This is the second of three releases planned for this gem. 
For reference: [BAC-1660](https://chowbus.atlassian.net/browse/BAC-1660)

[x] Add `time_zone` and `service_region_id` columns in `DelayHenka` models
[x] Add `time_zone` as parameter to schedule methods, with a default nil value
-- updates to monolith to utilize `time_zone` --
[ ] Modify workers to base changes/actions on time zone, require time_zone as a parameter for schedule methods   
